### PR TITLE
Use eatmydata for apt and dpkg instead of force-unsafe-io in dpkg

### DIFF
--- a/.github/workflows/tuned.yml
+++ b/.github/workflows/tuned.yml
@@ -21,8 +21,11 @@ jobs:
       run: sudo sed '/mime/d' -i /var/lib/dpkg/triggers/File
     - name: Disable hicolor icon theme triggers
       run: sudo sed '/hicolor-icon-theme/d' -i /var/lib/dpkg/triggers/File
-    - name: Enable unsafe dpkg IO
-      run: echo "force-unsafe-io" | sudo tee -a /etc/dpkg/dpkg.cfg.d/force-unsafe-io
+    - name: Enable eatmydata
+      run: |
+        echo -e '#!/bin/sh\nexec eatmydata /usr/bin/dpkg $@' | sudo tee /usr/local/bin/dpkg && sudo chmod +x /usr/local/bin/dpkg
+        echo -e '#!/bin/sh\nexec eatmydata /usr/bin/apt $@' | sudo tee /usr/local/bin/apt && sudo chmod +x /usr/local/bin/apt
+        echo -e '#!/bin/sh\nexec eatmydata /usr/bin/apt-get $@' | sudo tee /usr/local/bin/apt-get && sudo chmod +x /usr/local/bin/apt-get
     - name: Update apt sources
       run: sudo apt-get update -y
     - name: Install libguestfs-tools

--- a/speedup.sh
+++ b/speedup.sh
@@ -6,3 +6,9 @@ sudo sed '/install-info/d' -i /var/lib/dpkg/triggers/File
 sudo sed '/mime/d' -i /var/lib/dpkg/triggers/File
 sudo sed '/hicolor-icon-theme/d' -i /var/lib/dpkg/triggers/File
 echo "force-unsafe-io" | sudo tee -a /etc/dpkg/dpkg.cfg.d/force-unsafe-io
+if [ -a /usr/bin/eatmydata ]; then
+  echo "eatmydata available"
+  echo -e '#!/bin/sh\nexec eatmydata /usr/bin/dpkg $@' | sudo tee /usr/local/bin/dpkg && sudo chmod +x /usr/local/bin/dpkg
+  echo -e '#!/bin/sh\nexec eatmydata /usr/bin/apt $@' | sudo tee /usr/local/bin/apt && sudo chmod +x /usr/local/bin/apt
+  echo -e '#!/bin/sh\nexec eatmydata /usr/bin/apt-get $@' | sudo tee /usr/local/bin/apt-get && sudo chmod +x /usr/local/bin/apt-get
+fi


### PR DESCRIPTION
`force-unsafe-io` dpkg option does not disable all fsync() calls, only some of them, slowing down the installation.
Use eatmydata library wrapper to completely eliminate fsync() calls for apt, apt-get and dpkg.